### PR TITLE
fix: remove null_resource remove_installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ https://github.com/tigera/operator
 | <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 2.0.4 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >=2.0.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -98,7 +97,6 @@ No modules.
 | [kubernetes_namespace.calico_apiserver](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.calico_system](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.tigera_operator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
-| [null_resource.remove_installation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 


### PR DESCRIPTION
## 👀 Purpose

- Removes the null_resource which removes 2 finalizers and an installation in k8s, there should be one change when running this in pipelines.
- The fix that this replaces was introduced in 3.28.0 of the calico helm chart - https://github.com/projectcalico/calico/blob/v3.28.0/release-notes/v3.28.0-release-notes.md