### PR TITLE
chore: pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,12 +6,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@v1.0.0
+      uses: terraform-docs/gh-actions@f6d59f89a280fa0a3febf55ef68f146784b20ba0 # v1.0.0
       with:
         working-dir: .
         output-file: README.md

--- a/.github/workflows/push-terraform-module-version.yaml
+++ b/.github/workflows/push-terraform-module-version.yaml
@@ -7,7 +7,7 @@ jobs:
   push-terraform-module-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Export LATEST_TAG
         run: |
           echo "LATEST_TAG=$(curl \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           terraform_version: 1.2.5
           terraform_wrapper: false


### PR DESCRIPTION
### Description
This PR pins GitHub Actions to commit hashes for security.

### Related Issue
Closes https://github.com/ministryofjustice/cloud-platform-security-issues/issues/95 