### PR TITLE
chore: 🤖 upgrade chart from 3.28 to 3.29

### DIFF
--- a/calico.tf
+++ b/calico.tf
@@ -122,7 +122,7 @@ resource "helm_release" "tigera_calico" {
   repository = "https://projectcalico.docs.tigera.io/charts"
   namespace  = "tigera-operator"
   timeout    = 300
-  version    = "3.28.1"
+  version    = "3.29.6"
   skip_crds  = true
 
   set = [


### PR DESCRIPTION
## Purpose

This updates our Calico Helm chart and release to `3.29.6`

## Changes / Prerequisites

`3.29.x` introduces the new CRDs:

```
crd.projectcalico.org_tiers
policy.networking.k8s.io_adminnetworkpolicies
```

Since we're managing CRDs outside of the installation, these need to be installed prior to upgrading Calico, here:

https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf#L5-L30

relates to ministryofjustice/cloud-platform#7416