### PR TITLE
Bump 3.30.7

### DIFF
--- a/calico.tf
+++ b/calico.tf
@@ -122,13 +122,21 @@ resource "helm_release" "tigera_calico" {
   repository = "https://projectcalico.docs.tigera.io/charts"
   namespace  = "tigera-operator"
   timeout    = 300
-  version    = "3.29.6"
+  version    = "3.30.7"
   skip_crds  = true
 
   set = [
     {
       name  = "installation.kubernetesProvider"
       value = "EKS"
+    },
+    {
+      name  = "goldmane.enabled"
+      value = false
+    },
+    {
+      name  = "whisker.enabled"
+      value = false
     }
   ]
 

--- a/calico.tf
+++ b/calico.tf
@@ -137,6 +137,10 @@ resource "helm_release" "tigera_calico" {
     {
       name  = "whisker.enabled"
       value = false
+    },
+    {
+      name  = "manageCRDs"
+      value = true
     }
   ]
 

--- a/calico.tf
+++ b/calico.tf
@@ -140,7 +140,7 @@ resource "helm_release" "tigera_calico" {
     },
     {
       name  = "manageCRDs"
-      value = true
+      value = false
     }
   ]
 


### PR DESCRIPTION
## Purpose

- Upgrades Calico Tigera-Operator Helm release to 3.30.7

- Disables whisker and goldmane services introduced in 3.30 as we are not utilising these

- Disables Helm CRD management introduced in 3.30 as we manually manage Calico CRDs outside of module.

relates to ministryofjustice/cloud-platform#8262